### PR TITLE
コードブロック右端の Padding を修正

### DIFF
--- a/src/components/notion-blocks/code.tsx
+++ b/src/components/notion-blocks/code.tsx
@@ -40,11 +40,13 @@ const Code = ({ block }) => {
         <Mermaid id={`mermaid-${block.Id}`} definition={code} />
       ) : (
         <pre>
-          <code
-            dangerouslySetInnerHTML={{
-              __html: Prism.highlight(code, grammer, language),
-            }}
-          />
+          <div>
+            <code
+              dangerouslySetInnerHTML={{
+                __html: Prism.highlight(code, grammer, language),
+              }}
+            />
+          </div>
         </pre>
       )}
       {block.Code.Caption.length > 0 && block.Code.Caption[0].Text.Content ? (

--- a/src/styles/notion-block.module.css
+++ b/src/styles/notion-block.module.css
@@ -31,10 +31,22 @@
   line-height: 1.2rem;
   border-radius: var(--radius);
 }
+.code pre div {
+  position: relative;
+  display: inline-block;
+}
 .code pre code {
   color: var(--fg);
   padding: 0;
   background: rgb(247, 246, 243) !important;
+}
+.code pre div::after {
+  position: absolute;
+  top: 0;
+  left: 100%;
+  width: 0.8em;
+  height: 1px;
+  content: '';
 }
 
 .gray {


### PR DESCRIPTION
## 概要
コードブロックの右端 Padding が無視される事象が気になったので
![スクリーンショット 2022-10-05 午後9 01 12](https://user-images.githubusercontent.com/46078198/194055801-f64be2bc-22a7-440c-9af6-52dcca35d46e.png)

修正しました
![スクリーンショット 2022-10-05 午後9 01 23](https://user-images.githubusercontent.com/46078198/194055811-1f862517-0e44-4431-b9ce-d5eac3670102.png)

## 詳細
- 疑似要素で padding 同サイズの要素を右端に追加
- code タグを新たに div で包含

## 参考
https://note.com/takamoso/n/n587c4ea3dc7c#F7hsK